### PR TITLE
Update dirstream.cabal

### DIFF
--- a/dirstream.cabal
+++ b/dirstream.cabal
@@ -37,6 +37,6 @@ Library
     if os(windows)
         Build-Depends: Win32 >= 2.2.0.1 && < 2.4
     else
-        Build-Depends: unix  >= 2.5.1.0 && < 2.7.1
+        Build-Depends: unix  >= 2.5.1.0 && < 2.8.0.0
     Exposed-Modules: Data.DirStream
     GHC-Options: -O2 -Wall


### PR DESCRIPTION
The new `unix` that comes with `ghc-7.8-rc1` is `unix-2.7.0.0`. A simple `du`-like program I had around worked fine.
